### PR TITLE
Don't use ExUnit in production code

### DIFF
--- a/lib/sqids/alphabet.ex
+++ b/lib/sqids/alphabet.ex
@@ -1,6 +1,5 @@
 defmodule Sqids.Alphabet do
   @moduledoc false
-  import ExUnit.Assertions
 
   @min_alphabet_length 3
 
@@ -61,9 +60,6 @@ defmodule Sqids.Alphabet do
     alphabet_size = map_size(alphabet)
 
     map(alphabet, fn {index, char} ->
-      # assert index >= 0
-      # assert index < map_size(alphabet)
-
       new_index =
         if index < split_index do
           alphabet_size - split_index + index
@@ -71,8 +67,6 @@ defmodule Sqids.Alphabet do
           index - split_index
         end
 
-      # assert new_index >= 0
-      # assert new_index < map_size(alphabet)
       {new_index, char}
     end)
   end
@@ -82,9 +76,7 @@ defmodule Sqids.Alphabet do
     alphabet_size = map_size(alphabet)
 
     map(alphabet, fn {index, char} ->
-      # assert index < alphabet_size
       new_index = alphabet_size - index - 1
-      # assert new_index >= 0
       {new_index, char}
     end)
   end
@@ -106,12 +98,10 @@ defmodule Sqids.Alphabet do
   @spec index_of!(t(), byte) :: index
   def index_of!(%{} = alphabet, char) do
     # It would be nice to optimize this.
-
-    index =
-      Enum.find_value(alphabet, fn {index, byte} -> byte === char and index end)
-
-    assert index !== nil
-    index
+    case Enum.find_value(alphabet, fn {index, byte} -> byte === char and index end) do
+      nil -> raise "index was nil"
+      index -> index
+    end
   end
 
   ## Internal

--- a/scripts/update_blocklist.exs
+++ b/scripts/update_blocklist.exs
@@ -2,7 +2,6 @@
 
 defmodule Sqids.BlocklistUpdater do
   @moduledoc false
-  import ExUnit.Assertions
 
   require Logger
 

--- a/test/sqids_test.exs
+++ b/test/sqids_test.exs
@@ -141,6 +141,14 @@ defmodule SqidsTest do
 
     import SqidsTest.Shared
 
+    test "creating blocklist" do
+      expected_matches = ["aa", "ab", "ac"]
+      {:ok, %Sqids.Blocklist{} = blocklist} = Sqids.Blocklist.new(expected_matches, 1, "abc")
+
+      assert blocklist.min_word_length == 1
+      assert ^expected_matches = blocklist.matches_anywhere
+    end
+
     for access_type <- [:"Direct API", :"Using module"] do
       test "#{access_type}: if no custom blocklist param, use the default blocklist" do
         {:ok, instance} = new_sqids(unquote(access_type))

--- a/test/sqids_test.exs
+++ b/test/sqids_test.exs
@@ -20,7 +20,7 @@ defmodule SqidsTest do
 
     def new_sqids(:"Direct API", opts) do
       case Sqids.new(opts) do
-        {:ok, sqids} ->
+        {:ok, %Sqids{} = sqids} ->
           {:ok, {:direct_api, sqids}}
 
         {:error, _} = error ->


### PR DESCRIPTION
This changes the use of `assert` to raise on `nil`, and removes the commented out asserts

I'm actually not sure what tests to write to get this to fail